### PR TITLE
Fix multiple faults in doughnut animation and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <div id="raining-container"></div>
-    <div id="fact-popup" class="hidden">
+    <div id="fact-popup" class="hidden" role="dialog" aria-modal="true" aria-labelledby="fact-text" aria-hidden="true">
         <p id="fact-text"></p>
         <button id="close-popup">Close</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -4,10 +4,15 @@ const factText = document.getElementById('fact-text');
 const closePopupButton = document.getElementById('close-popup');
 
 const FACT_API_URL = 'https://uselessfacts.jsph.pl/random.json?language=en';
+const MAX_DOUGHNUTS = 30;
+let lastFocusedElement;
 
 function createDoughnut() {
     const doughnut = document.createElement('div');
     doughnut.classList.add('doughnut');
+    doughnut.setAttribute('role', 'button');
+    doughnut.setAttribute('tabindex', '0');
+    doughnut.setAttribute('aria-label', 'A falling doughnut, click to get a fact');
 
     // Randomize starting position, size, and animation duration
     doughnut.style.left = `${Math.random() * 100}vw`;
@@ -17,30 +22,61 @@ function createDoughnut() {
     const duration = Math.random() * 5 + 5; // Duration between 5s and 10s
     doughnut.style.animationDuration = `${duration}s`;
 
-    doughnut.addEventListener('click', async () => {
+    const showFact = async () => {
+        lastFocusedElement = document.activeElement;
         try {
             const response = await fetch(FACT_API_URL);
             const data = await response.json();
             factText.textContent = data.text;
             factPopup.classList.remove('hidden');
+            factPopup.setAttribute('aria-hidden', 'false');
+            closePopupButton.focus();
         } catch (error) {
             console.error('Error fetching fact:', error);
             factText.textContent = 'Could not fetch a fact. Please try again!';
             factPopup.classList.remove('hidden');
+            factPopup.setAttribute('aria-hidden', 'false');
+            closePopupButton.focus();
+        }
+    };
+
+    doughnut.addEventListener('click', showFact);
+    doughnut.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            showFact();
         }
     });
 
     rainingContainer.appendChild(doughnut);
 
-    // Remove doughnut from DOM after it falls out of view
-    setTimeout(() => {
+    // Remove doughnut from DOM when the animation ends
+    doughnut.addEventListener('animationend', () => {
         doughnut.remove();
-    }, duration * 1000);
+    });
 }
 
-closePopupButton.addEventListener('click', () => {
+function hideFact() {
     factPopup.classList.add('hidden');
+    factPopup.setAttribute('aria-hidden', 'true');
+    if (lastFocusedElement) {
+        lastFocusedElement.focus();
+    }
+}
+
+closePopupButton.addEventListener('click', hideFact);
+
+factPopup.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+        hideFact();
+    }
 });
 
-// Create a new doughnut every 500ms
-setInterval(createDoughnut, 500);
+
+// Create a new doughnut every 500ms, if not too many
+setInterval(() => {
+    const doughnutCount = rainingContainer.getElementsByClassName('doughnut').length;
+    if (doughnutCount < MAX_DOUGHNUTS) {
+        createDoughnut();
+    }
+}, 500);

--- a/style.css
+++ b/style.css
@@ -18,12 +18,12 @@ body {
     background-size: contain;
     background-repeat: no-repeat;
     cursor: pointer;
-    animation: fall linear infinite;
+    animation: fall linear;
 }
 
 @keyframes fall {
     to {
-        transform: translateY(100vh);
+        transform: translateY(calc(100vh + 50px)); /* 50px is max doughnut height */
     }
 }
 


### PR DESCRIPTION
This commit addresses several issues in the Raining Facts Donuts application:

1.  **Fixes Disappearing Doughnut on Hover:** Replaced the `setTimeout` based removal with an `animationend` event. This ensures that when you pause the animation by hovering, the doughnut does not get prematurely removed from the DOM.

2.  **Limits On-Screen Doughnuts:** Introduced a limit of 30 for the number of doughnuts that can be on-screen simultaneously. This prevents performance degradation from an excessive number of DOM elements.

3.  **Ensures Doughnuts Fall Off-Screen:** Adjusted the CSS falling animation to account for the doughnut's height, ensuring it moves completely out of the viewport.

4.  **Improves Accessibility:**
    *   Made doughnuts focusable and interactive via the keyboard (`Tab` to focus, `Enter`/`Space` to activate).
    *   Added appropriate ARIA roles (`button`, `dialog`) and labels to improve the screen reader experience.
    *   Implemented robust focus management for the fact popup, including returning focus on close and an `Escape` key handler.